### PR TITLE
カメラロール画像切り取りエリアを1:1から3:4へ変更

### DIFF
--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -139,24 +139,33 @@ final class YPAssetZoomableView: UIScrollView {
         var aspectRatio: CGFloat = 1
         var zoomScale: CGFloat = 1
 
-        if w > h { // Landscape
-            aspectRatio = h / w
+        // 📝 Forked by fumiyasac (2019/10/09)
+        // 切り取りエリアの縦横比を4:3へ変更したことに伴う調整対応
+        let heightRatioPrameter: CGFloat = 1.333
+
+        // MEMO: Case1. 横向き画像を読み込んだ場合の調整対応
+        if w > h {
+            aspectRatio = h / w  * heightRatioPrameter
             view.frame.size.width = screenWidth
             view.frame.size.height = screenWidth * aspectRatio
-        } else if h > w { // Portrait
+
+        // MEMO: Case2. 縦向き画像を読み込んだ場合の調整対応
+        } else if h > w {
             aspectRatio = w / h
             view.frame.size.width = screenWidth * aspectRatio
             view.frame.size.height = screenWidth
-            
             if let minWidth = minWidth {
                 let k = minWidth / screenWidth
-                zoomScale = (h / w) * k
+                zoomScale = (h / w) * k * heightRatioPrameter
             }
-        } else { // Square
+
+        // MEMO: Case3. 正方形画像を読み込んだ場合の調整対応
+        } else {
             view.frame.size.width = screenWidth
             view.frame.size.height = screenWidth
+            zoomScale = heightRatioPrameter
         }
-        
+
         // Centering image view
         view.center = center
         centerAssetView()

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -6,6 +6,9 @@
 //  Copyright © 2015 Yummypets. All rights reserved.
 //
 
+// 📝 Forked by fumiyasac (2019/10/09)
+// YPLibraryView.xibの縦横比を Vertical : Horizontal = 4 : 3としました。
+
 import UIKit
 import Stevia
 import Photos

--- a/Source/Pages/Gallery/YPLibraryView.xib
+++ b/Source/Pages/Gallery/YPLibraryView.xib
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clipsSubviews="YES" contentMode="scaleToFill" id="iN0-l3-epB" customClass="YPLibraryView" customModule="YPImagePicker" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="400" height="550"/>
+            <rect key="frame" x="0.0" y="0.0" width="400" height="684"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Cu-Zp-X0j">
-                    <rect key="frame" x="0.0" y="0.0" width="400" height="550"/>
+                    <rect key="frame" x="0.0" y="0.0" width="400" height="684"/>
                     <subviews>
                         <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="6id-Ro-HHC">
-                            <rect key="frame" x="0.0" y="400" width="400" height="150"/>
+                            <rect key="frame" x="0.0" y="533.5" width="400" height="150.5"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="jnu-mn-3OB">
                                 <size key="itemSize" width="60" height="60"/>
@@ -38,13 +37,10 @@
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="90B-0c-ych" userLabel="Image Crop View Container" customClass="YPAssetViewContainer" customModule="YPImagePicker" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="400" height="400"/>
+                    <rect key="frame" x="0.0" y="0.0" width="400" height="533.5"/>
                     <subviews>
                         <scrollView multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mc5-1c-z7q" customClass="YPAssetZoomableView" customModule="YPImagePicker" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="0.0" width="400" height="400"/>
-                            <constraints>
-                                <constraint firstAttribute="width" secondItem="Mc5-1c-z7q" secondAttribute="height" multiplier="1:1" id="Tue-WW-idi"/>
-                            </constraints>
+                            <rect key="frame" x="0.0" y="0.0" width="400" height="533.5"/>
                         </scrollView>
                     </subviews>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -52,7 +48,7 @@
                         <constraint firstItem="Mc5-1c-z7q" firstAttribute="leading" secondItem="90B-0c-ych" secondAttribute="leading" id="1DN-yd-Kyl"/>
                         <constraint firstAttribute="bottom" secondItem="Mc5-1c-z7q" secondAttribute="bottom" id="1Yc-V1-EBB"/>
                         <constraint firstItem="Mc5-1c-z7q" firstAttribute="top" secondItem="90B-0c-ych" secondAttribute="top" id="Jn1-QR-IAN"/>
-                        <constraint firstAttribute="width" secondItem="90B-0c-ych" secondAttribute="height" multiplier="1:1" id="coZ-5v-rE3"/>
+                        <constraint firstAttribute="width" secondItem="90B-0c-ych" secondAttribute="height" multiplier="3:4" id="coZ-5v-rE3"/>
                         <constraint firstAttribute="trailing" secondItem="Mc5-1c-z7q" secondAttribute="trailing" id="sKD-NK-t20"/>
                     </constraints>
                 </view>


### PR DESCRIPTION
### 概要

現在の仕様では切り取りエリアが1:1のパターンしかないので3:4のパターンを作成しました。